### PR TITLE
Fix xlsx import to unblock CI type-check

### DIFF
--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,5 +1,5 @@
 // @deno-types="https://cdn.sheetjs.com/xlsx-0.20.3/package/types/index.d.ts"
-import XLSX from 'xlsx';
+import * as XLSX from 'xlsx';
 
 export function escapeCsvValue(value: unknown): string {
   const stringValue = String(value ?? "");


### PR DESCRIPTION
## Problem

The `test` job started failing on **all** PRs with a type error in `src/utils/csv.ts` — a file most PRs don't touch:

```
TS1192 [ERROR]: Module '".../xlsx-0.20.3/package/types/index.d.ts"' has no default export.
import XLSX from 'xlsx';
```

### Root cause

`csv.ts` types the `xlsx` import from the SheetJS CDN via `@deno-types`:

```ts
// @deno-types="https://cdn.sheetjs.com/xlsx-0.20.3/package/types/index.d.ts"
import XLSX from 'xlsx';
```

That `.d.ts` exposes **only named exports** (`export function read`, `export const utils`, …) and **no default export**. The default import worked previously via TypeScript's synthetic-default interop, but CI uses a floating `deno-version: v2.x` (`.github/workflows/test.yml`), and a newer Deno/TypeScript now rejects it with TS1192. The types URL isn't pinned in `deno.lock` either, so the checking TS version drifts freely over time. This is why older PRs went green months ago but every run today fails, regardless of the change.

## Fix

Switch to a namespace import, which matches both the type declarations and the runtime ESM module:

```ts
import * as XLSX from 'xlsx';
```

All usages are already namespace-style (`XLSX.read`, `XLSX.write`, `XLSX.utils.sheet_to_csv`), so nothing else changes. This is version-independent — it fixes the actual export-shape mismatch rather than pinning the Deno version to freeze the drift.

## Verification

- `deno check src/utils/csv.ts` and the three consumers (`applicationController`, `resultController`, `ballotController`) all pass.
- Ran the runtime ESM module directly with `import * as XLSX`: a full CSV → XLSX → CSV roundtrip succeeds, and `read`/`write`/`utils` are all present.

Unblocks the `test` check on open PRs (e.g. #43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)